### PR TITLE
Movie recording

### DIFF
--- a/holypipette/devices/camera/camera.py
+++ b/holypipette/devices/camera/camera.py
@@ -38,6 +38,9 @@ class FileWriteThread(threading.Thread): # saves frames individually
     def run(self):
         self.running = True
         first_frame = None
+        if not os.path.exists(self.directory):
+            os.makedirs(self.directory)
+        
         while self.running:
             try:
                 if len(self.queue) > self.queue.maxlen // 2:
@@ -52,7 +55,7 @@ class FileWriteThread(threading.Thread): # saves frames individually
                     first_frame = frame_number
                 frame_number -= first_frame
 
-                fname = os.path.join(self.directory, f'image_{self.file_prefix}_{frame_number:05d}.tiff')
+                fname = os.path.join(self.directory, f'{self.file_prefix}_{frame_number:05d}.tiff')
                 imageio.imwrite(fname, frame)
                 time.sleep(self.debug_write_delay)
                 if frame_number % 20 == 0:

--- a/holypipette/devices/camera/camera.py
+++ b/holypipette/devices/camera/camera.py
@@ -122,7 +122,8 @@ class Camera(object):
         self._file_thread.start()
 
     def stop_recording(self):
-        self._file_thread.running = False
+        if self._file_thread:
+            self._file_thread.running = False
 
     def flip(self):
         self.flipped = not self.flipped

--- a/holypipette/devices/camera/opencvcamera.py
+++ b/holypipette/devices/camera/opencvcamera.py
@@ -25,6 +25,7 @@ class OpenCVCamera(Camera):
             self.video.set(4, height)
         self.width = int(self.video.get(3))
         self.height = int(self.video.get(4))
+        self.start_acquisition()
 
     def __del__(self):
         self.video.release()

--- a/holypipette/devices/camera/umanagercamera.py
+++ b/holypipette/devices/camera/umanagercamera.py
@@ -31,7 +31,6 @@ __all__ = ['uManagerCamera', 'Hamamatsu', 'Lumenera']
 class uManagerCamera(Camera):
     def __init__(self, brand, name, exposure):
         super(uManagerCamera, self).__init__()
-
         self.lock = threading.RLock()
         self.cam = MMCorePy.CMMCore()
         self.cam.loadDevice('Camera', brand, name)
@@ -53,6 +52,8 @@ class uManagerCamera(Camera):
         # Keep an old frame around to detect a frozen image
         self.comparison_time = None
         self.comparison_frame = None
+
+        self.start_acquisition()
 
     def __del__(self):
         self.cam.stopSequenceAcquisition()

--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -388,7 +388,7 @@ class CameraGui(QtWidgets.QMainWindow):
         pen = QtGui.QPen(QtGui.QColor(200, 0, 0, 125))
         pen.setWidth(4)
         painter.setPen(pen)
-        c_x, c_y = pixmap.width() / 2, pixmap.height() / 2
+        c_x, c_y = pixmap.width() // 2, pixmap.height() // 2
         painter.drawLine(c_x - 15, c_y, c_x + 15, c_y)
         painter.drawLine(c_x, c_y - 15, c_x, c_y + 15)
         painter.end()
@@ -425,21 +425,26 @@ class CameraGui(QtWidgets.QMainWindow):
         self.help_button = QtWidgets.QToolButton(clicked=self.toggle_help)
         self.help_button.setIcon(qta.icon('fa.question-circle'))
         self.help_button.setCheckable(True)
+        self.help_button.setToolTip('Toggle help window display')
 
         self.flip_button = QtWidgets.QToolButton(clicked=self.camera.flip,)
         self.flip_button.setIcon(qta.icon('fa.exchange'))
         self.flip_button.setCheckable(True)
+        self.flip_button.setToolTip('Flip image')
 
         self.log_button = QtWidgets.QToolButton(clicked=self.toggle_log)
         self.log_button.setIcon(qta.icon('fa.file'))
         self.log_button.setCheckable(True)
+        self.log_button.setToolTip('Toggle log window display')
 
         self.record_button = QtWidgets.QToolButton(clicked=self.toggle_recording)
         self.record_button.setIcon(qta.icon('fa.video-camera'))
         self.record_button.setCheckable(True)
+        self.record_button.setToolTip('Toggle video recording')
 
         self.autoexposure_button = QtWidgets.QToolButton(clicked=self.camera_interface.auto_exposure)
         self.autoexposure_button.setIcon(qta.icon('fa.camera'))
+        self.autoexposure_button.setToolTip('Use automatic exposure')
 
         self.status_bar.addPermanentWidget(self.help_button)
         self.status_bar.addPermanentWidget(self.log_button)
@@ -469,7 +474,7 @@ class CameraGui(QtWidgets.QMainWindow):
 
         self.display_edit_funcs = []
         if display_edit is None:
-            display_edit = []
+            display_edit = [self.draw_cross]
         if isinstance(display_edit, Sequence):
             self.display_edit_funcs.extend(display_edit)
         else:
@@ -538,6 +543,9 @@ class CameraGui(QtWidgets.QMainWindow):
             image = func(image)
         return image
 
+    def closeEvent(self, evt):
+       self.close()
+
     @command(category='General',
              description='Exit the application')
     def exit(self):
@@ -585,6 +593,7 @@ class CameraGui(QtWidgets.QMainWindow):
         Close the GUI.
         '''
         print('closing GUI')
+        self.camera.stop_recording()
         self.camera.stop_acquisition()
         del self.camera
         super(CameraGui, self).close()

--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -395,14 +395,14 @@ class CameraGui(QtWidgets.QMainWindow):
 
         self.display_edit_funcs = []
         if display_edit is None:
-            display_edit = self.draw_cross
-        if isinstance(display_edit, collections.Sequence):
+            display_edit = []
+        if isinstance(display_edit, collections.abc.Sequence):
             self.display_edit_funcs.extend(display_edit)
         else:
             self.display_edit_funcs.append(display_edit)
 
         self.image_edit_funcs = []
-        if isinstance(image_edit, collections.Sequence):
+        if isinstance(image_edit, collections.abc.Sequence):
             self.image_edit_funcs.extend(image_edit)
         elif image_edit is not None:
             self.image_edit_funcs.append(image_edit)
@@ -494,6 +494,8 @@ class CameraGui(QtWidgets.QMainWindow):
         '''
         Close the GUI.
         '''
+        print('closing GUI')
+        self.camera.acquisition_thread.running = False
         del self.camera
         super(CameraGui, self).close()
 

--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -546,6 +546,7 @@ class CameraGui(QtWidgets.QMainWindow):
 
     def closeEvent(self, evt):
        self.close()
+       return super(CameraGui, self).closeEvent(evt)
 
     @command(category='General',
              description='Exit the application')
@@ -587,7 +588,7 @@ class CameraGui(QtWidgets.QMainWindow):
                                                 'Increase/decrease exposure by 2.5ms')
         self.register_key_action(Qt.Key_I, None,
                                  self.camera_interface.save_image)
-        self.register_key_action(Qt.Key_R, None,
+        self.register_key_action(Qt.Key_I, Qt.SHIFT,
                                  self.toggle_recording)
 
     def close(self):
@@ -596,8 +597,9 @@ class CameraGui(QtWidgets.QMainWindow):
         '''
         if self.camera:
             print('closing GUI')
-            self.camera.stop_recording()
             self.camera.stop_acquisition()
+            self.camera.stop_recording()
+            self.camera.close()
             self.camera = None
         super(CameraGui, self).close()
 

--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -441,7 +441,8 @@ class CameraGui(QtWidgets.QMainWindow):
         self.record_button.setIcon(qta.icon('fa.video-camera'))
         self.record_button.setCheckable(True)
         self.record_button.setToolTip('Toggle video recording')
-
+        self.record_button.setStyleSheet('QToolButton:checked {background-color: red;}'
+        )
         self.autoexposure_button = QtWidgets.QToolButton(clicked=self.camera_interface.auto_exposure)
         self.autoexposure_button.setIcon(qta.icon('fa.camera'))
         self.autoexposure_button.setToolTip('Use automatic exposure')
@@ -592,10 +593,11 @@ class CameraGui(QtWidgets.QMainWindow):
         '''
         Close the GUI.
         '''
-        print('closing GUI')
-        self.camera.stop_recording()
-        self.camera.stop_acquisition()
-        del self.camera
+        if self.camera:
+            print('closing GUI')
+            self.camera.stop_recording()
+            self.camera.stop_acquisition()
+            self.camera = None
         super(CameraGui, self).close()
 
     def register_mouse_action(self, click_type, modifier, command,

--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -562,7 +562,8 @@ class CameraGui(QtWidgets.QMainWindow):
             dlg = RecordingDialog(self.base_directory, parent=self)
             if dlg.exec():
                 directory = os.path.abspath(dlg.directory_edit.text())
-                self.camera.start_recording(directory=directory)
+                prefix = dlg.prefix_edit.text()
+                self.camera.start_recording(directory=directory, file_prefix=prefix)
                 self.is_recording = True
         self.record_button.setChecked(self.is_recording)
 

--- a/holypipette/gui/camera.py
+++ b/holypipette/gui/camera.py
@@ -2,6 +2,12 @@
 from __future__ import absolute_import
 
 import collections
+# Support older versions of Python
+try:
+    from collections.abc import Sequence
+except ImportError:
+    from collections import Sequence
+
 import functools
 import logging
 import datetime
@@ -396,13 +402,13 @@ class CameraGui(QtWidgets.QMainWindow):
         self.display_edit_funcs = []
         if display_edit is None:
             display_edit = []
-        if isinstance(display_edit, collections.abc.Sequence):
+        if isinstance(display_edit, Sequence):
             self.display_edit_funcs.extend(display_edit)
         else:
             self.display_edit_funcs.append(display_edit)
 
         self.image_edit_funcs = []
-        if isinstance(image_edit, collections.abc.Sequence):
+        if isinstance(image_edit, Sequence):
             self.image_edit_funcs.extend(image_edit)
         elif image_edit is not None:
             self.image_edit_funcs.append(image_edit)

--- a/holypipette/gui/livefeed.py
+++ b/holypipette/gui/livefeed.py
@@ -55,7 +55,7 @@ class LiveFeedQt(QtWidgets.QLabel):
     def update_image(self):
         try:
             # get last frame from camera
-            _, _, _, frame = self.camera.last_frame()
+            frame = self.camera.last_frame()
             if frame is None:
                 return  # Frame acquisition thread has stopped
 

--- a/holypipette/gui/livefeed.py
+++ b/holypipette/gui/livefeed.py
@@ -54,11 +54,10 @@ class LiveFeedQt(QtWidgets.QLabel):
     @QtCore.pyqtSlot()
     def update_image(self):
         try:
-            # get data and display
-            queue = self.camera.queue
-            if not len(queue):
-                return  # nothing in the queue yet
-            _, _, _, frame = queue[-1]
+            # get last frame from camera
+            _, _, _, frame = self.camera.last_frame()
+            if frame is None:
+                return  # Frame acquisition thread has stopped
 
             if len(frame.shape) == 2:
                 # Grayscale image via MicroManager

--- a/holypipette/gui/livefeed.py
+++ b/holypipette/gui/livefeed.py
@@ -54,10 +54,12 @@ class LiveFeedQt(QtWidgets.QLabel):
     @QtCore.pyqtSlot()
     def update_image(self):
         try:
-            if not self.camera.new_frame():
-                return
             # get data and display
-            frame = self.camera.snap()
+            queue = self.camera.queue
+            if not len(queue):
+                return  # nothing in the queue yet
+            _, _, _, frame = queue[-1]
+
             if len(frame.shape) == 2:
                 # Grayscale image via MicroManager
                 if frame.dtype == np.dtype('uint32'):
@@ -71,7 +73,6 @@ class LiveFeedQt(QtWidgets.QLabel):
                 # Color image via OpenCV
                 bytesPerLine = 3*self.width
                 format = QtGui.QImage.Format_RGB888
-
             frame = self.image_edit(frame)
             q_image = QtGui.QImage(frame.data, self.width, self.height,
                                    bytesPerLine, format)

--- a/holypipette/interface/camera.py
+++ b/holypipette/interface/camera.py
@@ -80,6 +80,7 @@ class CameraInterface(TaskInterface):
             except (KeyError, IOError):
                 self.exception('Saving image as "%s" failed.' % fname)
 
+
     def show_tracked_objects(self, img):
         from holypipette.gui.movingList import moveList
         del moveList[:]


### PR DESCRIPTION
I've polished the movie recording, and integrated it in the `CameraGui` (all the other GUIs inherit from it, so they will have the functionality as well). There's a new button, or you can press Shift+I to start a recording. It proposes to create a new directory named with a name composed of current date and time, but you can choose another directory if necessary. The base directory in which this new directory is created is set as an argument to `CameraGui`, this should probably be somehow integrated in `setup_script.py` instead. If none is given, things end up in the `holypipette` directory itself.

I did test things with all the fake and debug cameras as well as `OpenCV`, but could not yet test it with MicroManager. In principle, it should work, but it might not have the fastest frame rate, since it asks for a frame at a time.